### PR TITLE
Fix instructor embeddings

### DIFF
--- a/code_snippets/08_instructor_embeddings.py
+++ b/code_snippets/08_instructor_embeddings.py
@@ -1,13 +1,13 @@
-from InstructorEmbedding import INSTRUCTOR
+from sentence_transformers import SentenceTransformer
 
 # Create virtual environment, install dependencies and run the code:
 # 1. Create: python3 -m venv instructor_venv
 # 2. Activate: source instructor_venv/bin/activate
-# 3. Install: pip install sentence-transformers==2.2.2 InstructorEmbedding==1.0.1
+# 3. Install: pip install sentence-transformers==3.3.0
 # 4. Run the code: python code_snippets/08_instructor_embeddings.py
 
 if __name__ == "__main__":
-    model = INSTRUCTOR("hkunlp/instructor-base")
+    model = SentenceTransformer("hkunlp/instructor-base")
 
     sentence = "RAG Fundamentals First"
 

--- a/llm_engineering/application/crawlers/dispatcher.py
+++ b/llm_engineering/application/crawlers/dispatcher.py
@@ -45,7 +45,7 @@ class CrawlerDispatcher:
         for pattern, crawler in self._crawlers.items():
             if re.match(pattern, url):
                 return crawler()
-            else:
-                logger.warning(f"No crawler found for {url}. Defaulting to CustomArticleCrawler.")
+        else:
+            logger.warning(f"No crawler found for {url}. Defaulting to CustomArticleCrawler.")
 
             return CustomArticleCrawler()

--- a/llm_engineering/application/crawlers/dispatcher.py
+++ b/llm_engineering/application/crawlers/dispatcher.py
@@ -45,7 +45,7 @@ class CrawlerDispatcher:
         for pattern, crawler in self._crawlers.items():
             if re.match(pattern, url):
                 return crawler()
-        else:
-            logger.warning(f"No crawler found for {url}. Defaulting to CustomArticleCrawler.")
+            else:
+                logger.warning(f"No crawler found for {url}. Defaulting to CustomArticleCrawler.")
 
             return CustomArticleCrawler()


### PR DESCRIPTION
Fixes the instructor embeddings code sample from Chapter 4 pp. 123

- use `sentence-transformers==3.3.0`
- removes InstructorEmbedding 

(as published, the code snippet throws `ImportError: cannot import name 'cached_download' from 'huggingface_hub'`)

Also fixes an indentation error in the the `CrawlerDispatcher` class