### PR TITLE
Update crawl_links.py

### DIFF
--- a/steps/etl/crawl_links.py
+++ b/steps/etl/crawl_links.py
@@ -48,7 +48,7 @@ def _crawl_link(dispatcher: CrawlerDispatcher, link: str, user: UserDocument) ->
 def _add_to_metadata(metadata: dict, domain: str, successfull_crawl: bool) -> dict:
     if domain not in metadata:
         metadata[domain] = {}
-    metadata[domain]["successful"] = metadata.get(domain, {}).get("successful", 0) + successfull_crawl
-    metadata[domain]["total"] = metadata.get(domain, {}).get("total", 0) + 1
+    metadata[domain]["successful"] = metadata[domain].get("successful", 0) + successfull_crawl
+    metadata[domain]["total"] = metadata[domain].get("total", 0) + 1
 
     return metadata


### PR DESCRIPTION
Refactor: Simplify `_add_to_metadata` function by removing redundant `metadata.get(domain, {})` calls