### PR TITLE
refactor: improve ch3 with setdefault, mongo simplification and consistent typing

### DIFF
--- a/llm_engineering/domain/base/nosql.py
+++ b/llm_engineering/domain/base/nosql.py
@@ -49,10 +49,6 @@ class NoSQLBaseDocument(BaseModel, Generic[T], ABC):
         if "_id" not in parsed and "id" in parsed:
             parsed["_id"] = str(parsed.pop("id"))
 
-        for key, value in parsed.items():
-            if isinstance(value, uuid.UUID):
-                parsed[key] = str(value)
-
         return parsed
 
     def model_dump(self: T, **kwargs) -> dict:

--- a/llm_engineering/domain/documents.py
+++ b/llm_engineering/domain/documents.py
@@ -1,5 +1,4 @@
 from abc import ABC
-from typing import Optional
 
 from pydantic import UUID4, Field
 
@@ -35,7 +34,7 @@ class RepositoryDocument(Document):
 
 
 class PostDocument(Document):
-    image: Optional[str] = None
+    image: str | None = None
     link: str | None = None
 
     class Settings:

--- a/steps/etl/crawl_links.py
+++ b/steps/etl/crawl_links.py
@@ -46,9 +46,8 @@ def _crawl_link(dispatcher: CrawlerDispatcher, link: str, user: UserDocument) ->
 
 
 def _add_to_metadata(metadata: dict, domain: str, successfull_crawl: bool) -> dict:
-    if domain not in metadata:
-        metadata[domain] = {}
-    metadata[domain]["successful"] = metadata.get(domain, {}).get("successful", 0) + successfull_crawl
-    metadata[domain]["total"] = metadata.get(domain, {}).get("total", 0) + 1
+    metadata.setdefault(domain, {"successful": 0, "total": 0})
+    metadata[domain]["successful"] += successfull_crawl
+    metadata[domain]["total"] += 1
 
     return metadata


### PR DESCRIPTION
This PR improves code quality in Chapter 3:

1. Enhance metadata handling:
   - Use dict.setdefault() in add_to_metadata for cleaner default value handling
   - Simplify code by removing redundant dictionary checks

2. Simplify MongoDB handling:
   - Remove redundant conversion logic in to_mongo method 

3. Modernize type hints:
   - Update to str | None syntax for consistency with surrounding code