### PR TITLE
Update nosql.py

### DIFF
--- a/llm_engineering/domain/base/nosql.py
+++ b/llm_engineering/domain/base/nosql.py
@@ -48,11 +48,7 @@ class NoSQLBaseDocument(BaseModel, Generic[T], ABC):
 
         if "_id" not in parsed and "id" in parsed:
             parsed["_id"] = str(parsed.pop("id"))
-
-        for key, value in parsed.items():
-            if isinstance(value, uuid.UUID):
-                parsed[key] = str(value)
-
+        
         return parsed
 
     def model_dump(self: T, **kwargs) -> dict:


### PR DESCRIPTION
Currently, there's a redundant UUID to string conversion happening in our NoSQLBaseDocument class. The `to_mongo` method performs UUID to string conversion even though this conversion is already handled by the overridden `model_dump` method.

Current flow:
1. `model_dump` converts all UUID values to strings
2. `to_mongo` calls `model_dump`
3. `to_mongo` then unnecessarily converts UUID values to strings again

Changes:
- Remove the redundant UUID conversion loop in `to_mongo`

Before:
```python
def to_mongo(self: T, **kwargs) -> dict:
    parsed = self.model_dump(...)
    if "_id" not in parsed and "id" in parsed:
        parsed["_id"] = str(parsed.pop("id"))
    for key, value in parsed.items():  # Redundant conversion
        if isinstance(value, uuid.UUID):
            parsed[key] = str(value)
    return parsed
```

After:
```python
def to_mongo(self: T, **kwargs) -> dict:
    parsed = self.model_dump(...)
    if "_id" not in parsed and "id" in parsed:
        parsed["_id"] = str(parsed.pop("id"))
    return parsed
```