### PR TITLE
Improve .env setup instructions for cross-platform copy-paste safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,10 +236,9 @@ Now, let's configure our local project with all the necessary credentials and to
 
 After you have installed all the dependencies, you must create and fill a `.env` file with your credentials to appropriately interact with other services and run the project. Setting your sensitive credentials in a `.env` file is a good security practice, as this file won't be committed to GitHub or shared with anyone else. 
 
-1. First, copy our example by running the following:
+1. First, copy our example by running the following at the root of your repository:
 
 ```bash
-# The file must be at the root of your repository!
 cp .env.example .env 
 ```
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,8 @@ After you have installed all the dependencies, you must create and fill a `.env
 1. First, copy our example by running the following:
 
 ```bash
-cp .env.example .env # The file must be at your repository's root!
+# The file must be at your repository's root!
+cp .env.example .env 
 ```
 
 2. Now, let's understand how to fill in all the essential variables within the `.env` file to get you started. The following are the mandatory settings we must complete when working locally:

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ After you have installed all the dependencies, you must create and fill a `.env
 1. First, copy our example by running the following:
 
 ```bash
-# The file must be at your repository's root!
+# The file must be at the root of your repository!
 cp .env.example .env 
 ```
 


### PR DESCRIPTION
This PR updates the README instructions for creating the .env file:

Removed the inline comment (# The file must be at your repository's root!) from the code block.

Moved the note into the step description instead (at the root of your repository).

Ensures the code block contains only the command (cp .env.example .env), making it copy-paste safe across macOS, Linux, and Windows shells (Bash, Zsh, PowerShell, CMD).

Improves readability by keeping explanatory text outside the command snippet.

**Why:**
Including inline comments in the code block could cause errors when users copy-paste, especially in Zsh ( like it did in mine! )  or Windows CMD where # isn’t always treated as a comment. This change makes onboarding smoother and avoids confusion for new contributors.